### PR TITLE
add Python2 shebang

### DIFF
--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python2
 import os
 import stat
 import argparse


### PR DESCRIPTION
Allow running Salsa script as command, ensuring python2.
This makes maintenance of salsa installations easier. 