### PR TITLE
added -O for original coordinates agp

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ The new version of SALSA has been designed to consider several use cases dependi
 
 ```
 python run_pipeline.py -h
-usage: run_pipeline.py [-h] -a ASSEMBLY -l LENGTH -b BED [-o OUTPUT]
-                       [-c CUTOFF] [-g GFA] [-u UNITIGS] [-e ENZYME]
-                       [-i ITER] [-x DUP] [-s EXP] [-m CLEAN]
+usage: run_pipeline.py [-h] -a ASSEMBLY -l LENGTH -b BED [-o OUTPUT] [-O]
+                       [-c CUTOFF] [-g GFA] [-e ENZYME] [-i ITER] [-x DUP]
+                       [-s EXP] [-m CLEAN] [-f FILTER] [-p PRNT]
 
 SALSA Iterative Pipeline
 
@@ -43,6 +43,9 @@ optional arguments:
   -b BED, --bed BED     Bed file of alignments sorted by read names
   -o OUTPUT, --output OUTPUT
                         Output directory to put results
+  -O, --output-original-coords
+                        Run python run_pipeline.py -h to see the help
+                        message for this option.
   -c CUTOFF, --cutoff CUTOFF
                         Minimum contig length to scaffold, default=1000
   -g GFA, --gfa GFA     GFA file for assembly
@@ -54,6 +57,10 @@ optional arguments:
   -m CLEAN, --clean CLEAN
                         Set this option to "yes" if you want to find
                         misassemblies in input assembly
+  -f FILTER, --filter FILTER
+                        Filter bed file for contigs present in the assembly
+  -p PRNT, --prnt PRNT  Set this option to "yes" if you want to output the
+                        scaffolds sequence and agp file for each iteration
 ```
 
 ### Mapping Reads

--- a/get_seq.py
+++ b/get_seq.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python2
+import sys
+import re
 import pickle
 import argparse
 
@@ -21,11 +23,64 @@ def parse_fasta(fh):
         fa[short_name] = ''.join(nuc_list)
     return fa
 
+# return value is a dictionary. keys=str, values=int.
+# the keys are tig names and the values are break points.
+# It is the result of parsing the input_breaks file generated
+# from cleaning the input assembly to SALSA using break_contigs_start.cpp.
+# input param: fn is the filename (a string) of the input_breaks file.
+def parse_breaks(fn):
+    if fn is None:
+        return None
+    breaks = {}
+    with open(fn, 'r') as fh:
+        for line in fh:
+            fields = line.rstrip('\n').split('\t')
+            tigname = fields[0]          # original tig name (i.e., before _1 & _2 were appended)
+            break_point = int(fields[1]) # first position of next segment (0-based). Alternately, last position of first segment (1-based, inclusive).
+            assert not tigname in breaks # if a contig is broken multiple times (reported in input_breaks 2+ times), we need to handle things differently here
+            #                            # (e.g., by using a list of positions instead of a single position), which will have implications elsewhere too (obviously)
+            breaks[tigname] = break_point
+    return breaks
+
+# returns two values, a string and an integer.
+# input params: name is the tig names from the cleaned fasta (i.e., not scaffold_* (unless the input to salsa was also named that way))
+#               position is the start position we're about to write to an agp file
+#               breaks_map is the dictionary generated from the parse_breaks function (cannot be None)
+def convertToPreCleanedNamesAndCoords(name, position, breaks_map):
+    assert not breaks_map is None # If breaks_map were None, we wouldn't have the necessary information to possibly update name and position
+
+    # initialize the return values
+    orig_name = name
+    orig_pos = position
+
+    if not re.search(r"_[12]$", name) is None:
+        # name pattern indicates it may be a broken/cleaned tig
+        possible_orig_name = name[:-2]
+
+        if possible_orig_name in breaks_map:
+            # the un-suffixed name was in breaks_map as a key, so it is a broken/cleaned tig
+
+            orig_name = possible_orig_name # save the actual original name
+            break_pos = breaks_map[orig_name] # extract the break point
+
+            if not re.search(r"_[2]$", name) is None:
+                # the name pattern indicates that we're dealing with the part of the tig after
+                # the break point. If it had been the first portion (i.e., _1), we wouldn't
+                # update the position because it would already be in the correct coordinate space.
+                # Since we aren't in the first portion, we do need to add the length of the first
+                # portion to our position so we are in the correct coordinate space.
+                orig_pos +=  break_pos
+
+    # return the (possibly updated) name and position
+    return orig_name, orig_pos
+
 parser = argparse.ArgumentParser()
-parser.add_argument("-a","--cleaned",help="cleaned assembly")
-parser.add_argument("-f","--scaffold",help="final scaffold file")
-parser.add_argument("-g","--agp",help="agp file")
-parser.add_argument("-p","--map",help="pickle map of scaffolds")
+parser.add_argument("-a","--cleaned",help="cleaned assembly (input, required)")
+parser.add_argument("-b","--breaks", help="input_breaks file resulting from cleaning input assembly. The -G option must be supplied for this to work. (input, optional)")
+parser.add_argument("-f","--scaffold",help="final scaffold file (output, required)")
+parser.add_argument("-g","--agp",help="agp file (output, required)")
+parser.add_argument("-G","--agp-orig-coords", dest="agp_oc", help="agp file with the original names and coordinates from the input assembly before cleaning. The -b option must be supplied for this to work. (output, optional)")
+parser.add_argument("-p","--map",help="pickle map of scaffolds (input, required)")
 
 args = parser.parse_args()
 
@@ -34,6 +89,12 @@ scaff_map = pickle.load(open(args.map,'r'))
 
 contig_length = {}
 id2seq = {}
+
+if bool(args.breaks) ^ bool(args.agp_oc):
+    sys.stderr.write("ERROR: Both -b, --breaks and -G, --agp-orig-coords must be supplied together. None or both are fine, but not one only.\n")
+    sys.exit(1)
+write_agp_orig_coords = bool(args.agp_oc) # true if we should write the special agp file, false otherwise.
+breaks = parse_breaks(args.breaks)
 
 id2seq = parse_fasta(open(args.cleaned,'r'))
 for key in id2seq:
@@ -44,78 +105,78 @@ for key in id2seq:
 
 scaff2length = {}
 for scaffold in scaff_map:
-	path = scaff_map[scaffold]
-	length = 0
-	for i in xrange(0,len(path)-1,2):
-		length += contig_length[path[i].split(':')[0]]
-	scaff2length[scaffold] = length
+    path = scaff_map[scaffold]
+    length = 0
+    for i in xrange(0,len(path)-1,2):
+        length += contig_length[path[i].split(':')[0]]
+    scaff2length[scaffold] = length
 
 sorted_scaffolds = sorted(scaff2length.items(), key=lambda x: x[1],reverse=True)
 
 c_id = 1
-line = ""
-agp_output = open(args.agp,'w')
-ofile = open(args.scaffold,'w')
-for key in sorted_scaffolds:
-    #print 'scaffold_'+str(c_id) + '\t' + key
-    key = key[0]
-    start = 1
-    local_comp = 1
-    #if len(scaff_map[key]) >= 4:
-    path = scaff_map[key]
-    scaff_len = 0
-    curr_contig = ""
-    #print c_id
-    line = ''
-    for i in range(0,len(path)-1,2):
-        line += "scaffold_"+str(c_id)
-        line += '\t'
-        line += str(start)
-        line += str('\t')
-        curr = path[i]
-        next = path[i+1]
-        curr = curr.split(':')
-        next = next.split(':')
-        curr_len = contig_length[curr[0]]
-        scaff_len += curr_len
-        end = curr_len + start - 1
-        line += str(end)
-        line += '\t'
-        start = end + 1
-        line += str(local_comp)
-        local_comp += 1
-        line += ('\tW\t' + curr[0] + '\t' + '1\t')
-        line += str(curr_len)
-        line += '\t'
-        #print curr
-        if curr[1] == 'B' and next[1] == 'E':
-            curr_contig += id2seq[curr[0]]
-            line += '+\t'
-        if curr[1] == 'E' and next[1] == 'B':
-            line += '-\t'
-            #print id2seq[curr[0]]
-            curr_contig += revcompl(id2seq[curr[0]])
+with open(args.agp, 'w') as agp_output:
+    with open(args.scaffold, 'w') as ofile:
+        agp_origcoords_output = open(args.agp_oc, 'w') if write_agp_orig_coords else None
+        for key in sorted_scaffolds:
+            #print 'scaffold_'+str(c_id) + '\t' + key
+            key = key[0]
+            start = 1
+            local_comp = 1
+            #if len(scaff_map[key]) >= 4:
+            path = scaff_map[key]
+            scaff_len = 0
+            curr_contig = ""
+            #print c_id
+            for i in range(0,len(path)-1,2):
 
-        agp_output.write(line+'\n')
-        if i != len(path) - 2:
-            for j in range(0,500):
-                curr_contig += 'N'
-            line = ""
-            line += "scaffold_"+str(c_id)+'\t'
-            line += str(start) +'\t'
-            end = 500 + start - 1
-            line += str(end) + '\t'
-            start = end + 1
-            line += str(local_comp) +'\t'
-            local_comp += 1
-            line += 'N\t500\tscaffold\tyes\tna'
-            agp_output.write(line+'\n')
-            line=""
-    # rec = SeqRecord(Seq(curr_contig,generic_dna),id='scaffold_'+str(c_id))
-    # recs.append(rec)
-    # print c_id
-    chunks = [curr_contig[i:i+80] for i in xrange(0,len(curr_contig),80)]
-    ofile.write('>scaffold_'+str(c_id)+'\n')
-    for chunk in chunks:
-        ofile.write(chunk+'\n')
-    c_id += 1
+                curr = path[i].split(':')
+                next = path[i+1].split(':')
+                curr_len = contig_length[curr[0]]
+                scaff_len += curr_len
+                end = curr_len + start - 1
+                direction = ''
+                if curr[1] == 'B' and next[1] == 'E':
+                    curr_contig += id2seq[curr[0]]
+                    direction = '+'
+                if curr[1] == 'E' and next[1] == 'B':
+                    curr_contig += revcompl(id2seq[curr[0]])
+                    direction = '-'
+                #             0............................................................................................0  1.....1  2.2  3...........3  4..............4
+                line_parts = ["scaffold_" + str(c_id) + '\t' + str(start) + '\t' + str(end) + '\t' + str(local_comp) + "\tW", curr[0], '1', str(curr_len), direction + '\n']
+                agp_output.write('\t'.join(line_parts))
+                if write_agp_orig_coords:
+                    orig_name, orig_start = convertToPreCleanedNamesAndCoords(curr[0], 1, breaks)
+                    orig_end = curr_len + orig_start - 1
+                    line_parts[1] = orig_name
+                    line_parts[2] = str(orig_start)
+                    line_parts[3] = str(orig_end)
+                    agp_origcoords_output.write('\t'.join(line_parts))
+                    # note: line_parts is unsafe to use after this if block w/o reassigning the start/end and name:
+                    #line_parts[1] = curr[0]
+                    #line_parts[2] = '1'
+                    #line_parts[3] = str(curr_len)
+
+                start = end + 1
+                local_comp += 1
+
+                if i != len(path) - 2:
+                    curr_contig += 'N' * 500
+
+                    end = 500 + start - 1
+                    line = "scaffold_" + str(c_id) + '\t' + str(start) + '\t' + str(end) + '\t' + str(local_comp) + '\t' + "N\t500\tscaffold\tyes\tna\n"
+                    agp_output.write(line)
+                    if write_agp_orig_coords:
+                        agp_origcoords_output.write(line)
+                    start = end + 1
+                    local_comp += 1
+            # rec = SeqRecord(Seq(curr_contig,generic_dna),id='scaffold_'+str(c_id))
+            # recs.append(rec)
+            # print c_id
+            chunks = [curr_contig[i:i+80] for i in xrange(0,len(curr_contig),80)]
+            ofile.write('>scaffold_'+str(c_id)+'\n')
+            for chunk in chunks:
+                ofile.write(chunk+'\n')
+            c_id += 1
+
+        if write_agp_orig_coords:
+            agp_origcoords_output.close()


### PR DESCRIPTION
Added `-O` for original coordinates agp, which required adding `-b` and `-G` to `get_seq.py`. Refactored part of `get_seq.py` to simplify string building and use consistent whitespace. Removed trailing tab in output agp. Also updated readme.

The differences in `get_seq.py` probably look larger than they are because I used `with` statements when opening some of the files which changed the indentation levels. I tested my refactoring independently of the changes to add the original coordinates functionality.

Summary of functional changes:
Supplying the `-O` flag to `run_pipeline.py` will cause `get_seq.py` to be called with its new `-b` and `-G` options. `-b` provides input (the `input_breaks` file) and `-G` tells it where to write the extra AGP file with the original coordinates (as opposed to the coordinates from `assembly.cleaned.fasta`). Since the extra output filename is controlled by `run_pipeline.py` and not directly exposed to the user, the output names match the pattern: `<name>.original-coordinates.agp`, where `<name>` is `scaffolds_FINAL` at the end of the pipeline and `scaffolds_ITERATION_#` in intermediate steps (if `-p` was supplied to `run_pipeline.py`). The regular output (e.g., `scaffolds_FINAL.agp`) is still output and is identical regardless of whether the user supplies the new `-O` flag.

Run times are not significantly affected by this change despite the extra work, presumably because the extra computation is trivial, the extra files are small, and the refactoring prevents the repeated copying of strings.